### PR TITLE
perf: Pass originator as 0 address

### DIFF
--- a/src/utils/calls/aggregator.ts
+++ b/src/utils/calls/aggregator.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, PayableOverrides, Signer } from "ethers";
+import { BigNumber, constants, Contract, PayableOverrides, Signer } from "ethers";
 import { TradeData } from "../../types";
 import abiLooksRareAggregator from "../../abis/LooksRareAggregator.json";
 import { LooksRareAggregator } from "../../../typechain";
@@ -12,10 +12,9 @@ export const executeETHOrders = async (
   overrides?: PayableOverrides
 ) => {
   const contract = new Contract(address, abiLooksRareAggregator, signer) as LooksRareAggregator;
-
-  // NOTE: Maybe make it 0 address to save gas, since the contract will set it to msg.sender anyway.
-  const originator = await signer.getAddress();
-
+  // NOTE: The aggregator contract sets originator as msg.sender no matter what, so we can save
+  // a bit of gas by passing 0 bytes.
+  const originator = constants.AddressZero;
   return contract.execute([], tradeData, originator, recipient, isAtomic, { ...overrides });
 };
 
@@ -28,9 +27,8 @@ export const executeETHOrdersGasEstimate = async (
   overrides?: PayableOverrides
 ): Promise<BigNumber> => {
   const contract = new Contract(address, abiLooksRareAggregator, signer) as LooksRareAggregator;
-
-  // NOTE: Maybe make it 0 address to save gas, since the contract will set it to msg.sender anyway.
-  const originator = await signer.getAddress();
-
+  // NOTE: The aggregator contract sets originator as msg.sender no matter what, so we can save
+  // a bit of gas by passing 0 bytes.
+  const originator = constants.AddressZero;
   return await contract.estimateGas.execute([], tradeData, originator, recipient, isAtomic, { ...overrides });
 };


### PR DESCRIPTION
https://github.com/LooksRare/contracts-aggregator/blob/master/contracts/LooksRareAggregator.sol#L68

For ETH orders, LooksRareAggregator sets `originator` as `msg.sender` no matter what is being passed, so we can save some gas by passing 0 as the `originator`