### PR TITLE
feat: Split orders by referrer (#65)

### DIFF
--- a/src/__tests__/aggregatorExecuteLooksRareV2.test.ts
+++ b/src/__tests__/aggregatorExecuteLooksRareV2.test.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import calculateTxFee from "./helpers/calculateTxFee";
 import { setUpContracts, Mocks, getSigners, getAddressOverrides } from "./helpers/setup";
 import { LooksRareAggregator } from "../LooksRareAggregator";
-import { ContractMethods } from "../types";
+import { ContractMethods, TradeData } from "../types";
 import { Addresses } from "../constants/addresses";
 import { constants, Contract, ContractTransaction } from "ethers";
 import { MakerOrderFromAPI } from "../interfaces/LooksRareV2";
@@ -13,25 +13,25 @@ import { setBalance } from "./helpers/setBalance";
 
 describe("LooksRareAggregator class", () => {
   let contracts: Mocks;
+  const balanceBeforeTx = ethers.utils.parseEther("4");
 
   beforeEach(async () => {
     contracts = await setUpContracts();
   });
 
-  const executeLooksRareV2Order = async (
+  const createMakerOrderFromAPI = async (
     maker: SignerWithAddress,
     collection: Contract,
     collectionType: CollectionType,
     currency: string,
     itemIds: [string],
-    amounts: [string]
-  ): Promise<ContractTransaction> => {
+    amounts: [string],
+    referrer?: SignerWithAddress,
+    nonce = 0
+  ): Promise<MakerOrderFromAPI> => {
     const chainId = ChainId.MAINNET;
     const signers = await getSigners();
     const buyer = signers.buyer;
-    const addresses: Addresses = getAddressOverrides(contracts);
-
-    const aggregator = new LooksRareAggregator(buyer, chainId, addresses);
 
     const blockNumber = await ethers.provider.getBlockNumber();
     const block = await ethers.provider.getBlock(blockNumber);
@@ -45,8 +45,8 @@ describe("LooksRareAggregator class", () => {
     const makerOrder: Maker = {
       quoteType: QuoteType.Ask,
       globalNonce: 0,
-      subsetNonce: 0,
-      orderNonce: 0,
+      subsetNonce: nonce,
+      orderNonce: nonce,
       strategyId: 0,
       collectionType,
       collection: collection.address,
@@ -67,19 +67,34 @@ describe("LooksRareAggregator class", () => {
     const signature = await maker._signTypedData(domain, utils.makerTypes, makerOrder);
 
     // Fake an order from the API
-    const makerOrderFromAPI: MakerOrderFromAPI = {
+    return {
       merkleTree,
       signature,
+      referrer: referrer && {
+        rate: 0,
+        address: referrer.address,
+      },
       ...makerOrder,
     };
+  };
+
+  const executeAggregator = async (
+    maker: SignerWithAddress,
+    collection: Contract,
+    makerOrdersFromAPI: Array<MakerOrderFromAPI>
+  ): Promise<ContractTransaction> => {
+    const chainId = ChainId.MAINNET;
+    const signers = await getSigners();
+    const buyer = signers.buyer;
+    const addresses: Addresses = getAddressOverrides(contracts);
+
+    const aggregator = new LooksRareAggregator(buyer, chainId, addresses);
 
     const { tradeData, actions } = await aggregator.transformListings({
       seaport_V1_4: [],
       seaport_V1_5: [],
-      looksRareV2: [makerOrderFromAPI],
+      looksRareV2: makerOrdersFromAPI,
     });
-
-    const balanceBeforeTx = ethers.utils.parseEther("2");
 
     await setBalance(buyer.address, balanceBeforeTx);
 
@@ -97,20 +112,41 @@ describe("LooksRareAggregator class", () => {
     return await contractMethods.call();
   };
 
+  const executeSingleLooksRareV2Order = async (
+    maker: SignerWithAddress,
+    collection: Contract,
+    collectionType: CollectionType,
+    currency: string,
+    itemIds: [string],
+    amounts: [string],
+    referrer: SignerWithAddress
+  ): Promise<ContractTransaction> => {
+    const makerOrderFromAPI = await createMakerOrderFromAPI(
+      maker,
+      collection,
+      collectionType,
+      currency,
+      itemIds,
+      amounts,
+      referrer
+    );
+
+    return await executeAggregator(maker, collection, [makerOrderFromAPI]);
+  };
+
   it("can execute LooksRare V2 orders (Buy ERC721 with ETH)", async () => {
     const collection = contracts.collection1;
     const signers = await getSigners();
     const buyer = signers.buyer;
-    const tx = await executeLooksRareV2Order(
+    const tx = await executeSingleLooksRareV2Order(
       signers.user1,
       collection,
       CollectionType.ERC721,
       constants.AddressZero,
       ["1"],
-      ["1"]
+      ["1"],
+      signers.user2
     );
-
-    const balanceBeforeTx = ethers.utils.parseEther("2");
 
     expect(await collection.ownerOf(1)).to.equal(buyer.address);
     expect(await collection.balanceOf(buyer.address)).to.equal(1);
@@ -124,16 +160,15 @@ describe("LooksRareAggregator class", () => {
     const collection = contracts.collection3;
     const signers = await getSigners();
     const buyer = signers.buyer;
-    const tx = await executeLooksRareV2Order(
+    const tx = await executeSingleLooksRareV2Order(
       signers.user3,
       collection,
       CollectionType.ERC1155,
       constants.AddressZero,
       ["3"],
-      ["2"]
+      ["2"],
+      signers.user2
     );
-
-    const balanceBeforeTx = ethers.utils.parseEther("2");
 
     expect(await collection.balanceOf(buyer.address, 3)).to.equal(2);
 
@@ -147,7 +182,6 @@ describe("LooksRareAggregator class", () => {
     const signers = await getSigners();
     const buyer = signers.buyer;
 
-    const balanceBeforeTx = ethers.utils.parseEther("2");
     await contracts.weth.mint(buyer.address, balanceBeforeTx);
 
     await contracts.looksRareAggregator.approve(
@@ -156,13 +190,14 @@ describe("LooksRareAggregator class", () => {
       ethers.constants.MaxUint256
     );
 
-    await executeLooksRareV2Order(
+    await executeSingleLooksRareV2Order(
       signers.user1,
       collection,
       CollectionType.ERC721,
       contracts.weth.address,
       ["1"],
-      ["1"]
+      ["1"],
+      signers.user2
     );
 
     expect(await collection.ownerOf(1)).to.equal(buyer.address);
@@ -177,7 +212,6 @@ describe("LooksRareAggregator class", () => {
     const signers = await getSigners();
     const buyer = signers.buyer;
 
-    const balanceBeforeTx = ethers.utils.parseEther("2");
     await contracts.weth.mint(buyer.address, balanceBeforeTx);
 
     await contracts.looksRareAggregator.approve(
@@ -186,18 +220,211 @@ describe("LooksRareAggregator class", () => {
       ethers.constants.MaxUint256
     );
 
-    await executeLooksRareV2Order(
+    await executeSingleLooksRareV2Order(
       signers.user3,
       collection,
       CollectionType.ERC1155,
       contracts.weth.address,
       ["3"],
-      ["2"]
+      ["2"],
+      signers.user2
     );
 
     expect(await collection.balanceOf(buyer.address, 3)).to.equal(2);
 
     const balanceAfterTx = await contracts.weth.balanceOf(buyer.address);
     expect(balanceBeforeTx.sub(balanceAfterTx)).to.equal(constants.WeiPerEther);
+  });
+
+  it("can group orders with different referrers into different TradeData", async () => {
+    const collection = contracts.collection1;
+    const signers = await getSigners();
+    const chainId = ChainId.MAINNET;
+    const addresses: Addresses = getAddressOverrides(contracts);
+    const buyer = signers.buyer;
+    const makerOrderUser1 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user2
+    );
+    const makerOrderUser2 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user2
+    );
+    const makerOrderUser3 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user3
+    );
+
+    const aggregator = new LooksRareAggregator(buyer, chainId, addresses);
+    const { tradeData } = await aggregator.transformListings({
+      seaport_V1_4: [],
+      seaport_V1_5: [],
+      looksRareV2: [makerOrderUser1, makerOrderUser2, makerOrderUser3],
+    });
+
+    const user2Bytes = ethers.utils.defaultAbiCoder.encode(["address"], [signers.user2.address]);
+    const user3Bytes = ethers.utils.defaultAbiCoder.encode(["address"], [signers.user3.address]);
+
+    expect(tradeData.length).to.equal(2);
+    tradeData.forEach((td: TradeData) => {
+      if (td.orders.length == 2) {
+        expect(td.extraData).to.equal(user2Bytes);
+      } else if (td.orders.length == 1) {
+        expect(td.extraData).to.equal(user3Bytes);
+      } else {
+        expect.fail("failed order grouping by referrer");
+      }
+    });
+  });
+
+  it("can group orders with no referrer into same TradeData", async () => {
+    const collection = contracts.collection1;
+    const signers = await getSigners();
+    const chainId = ChainId.MAINNET;
+    const addresses: Addresses = getAddressOverrides(contracts);
+    const buyer = signers.buyer;
+    const makerOrderUser1 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"]
+    );
+    const makerOrderUser2 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"]
+    );
+    const makerOrderUser3 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user3
+    );
+
+    const aggregator = new LooksRareAggregator(buyer, chainId, addresses);
+    const { tradeData } = await aggregator.transformListings({
+      seaport_V1_4: [],
+      seaport_V1_5: [],
+      looksRareV2: [makerOrderUser1, makerOrderUser2, makerOrderUser3],
+    });
+
+    const user3Bytes = ethers.utils.defaultAbiCoder.encode(["address"], [signers.user3.address]);
+
+    expect(tradeData.length).to.equal(2);
+    tradeData.forEach((td: TradeData) => {
+      if (td.orders.length == 2) {
+        expect(td.extraData).to.equal(constants.HashZero);
+      } else if (td.orders.length == 1) {
+        expect(td.extraData).to.equal(user3Bytes);
+      } else {
+        expect.fail("failed order grouping by referrer");
+      }
+    });
+  });
+
+  it("can group orders with same referrers into single TradeData", async () => {
+    const collection = contracts.collection1;
+    const signers = await getSigners();
+    const chainId = ChainId.MAINNET;
+    const addresses: Addresses = getAddressOverrides(contracts);
+    const buyer = signers.buyer;
+    const makerOrderUser1 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user2
+    );
+    const makerOrderUser2 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user2
+    );
+
+    const aggregator = new LooksRareAggregator(buyer, chainId, addresses);
+    const { tradeData } = await aggregator.transformListings({
+      seaport_V1_4: [],
+      seaport_V1_5: [],
+      looksRareV2: [makerOrderUser1, makerOrderUser2],
+    });
+
+    const user2Bytes = ethers.utils.defaultAbiCoder.encode(["address"], [signers.user2.address]);
+
+    expect(tradeData.length).to.equal(1);
+    expect(tradeData[0].extraData).to.equal(user2Bytes);
+  });
+
+  it("can execute orders with multiple referrers", async () => {
+    const collection = contracts.collection1;
+    const signers = await getSigners();
+    const buyer = signers.buyer;
+    const makerOrderUser1 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["1"],
+      ["1"],
+      signers.user2,
+      0
+    );
+    const makerOrderUser2 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["2"],
+      ["1"],
+      signers.user2,
+      1
+    );
+    const makerOrderUser3 = await createMakerOrderFromAPI(
+      signers.user1,
+      collection,
+      CollectionType.ERC721,
+      constants.AddressZero,
+      ["3"],
+      ["1"],
+      signers.user3,
+      2
+    );
+
+    const tx = await executeAggregator(signers.user1, collection, [makerOrderUser1, makerOrderUser2, makerOrderUser3]);
+
+    expect(await collection.ownerOf(1)).to.equal(buyer.address);
+    expect(await collection.balanceOf(buyer.address)).to.equal(3);
+
+    const txFee = await calculateTxFee(tx);
+    const balanceAfterTx = await ethers.provider.getBalance(buyer.address);
+    expect(balanceBeforeTx.sub(balanceAfterTx).sub(txFee)).to.equal(constants.WeiPerEther.mul(3));
   });
 });

--- a/src/interfaces/LooksRareV2.ts
+++ b/src/interfaces/LooksRareV2.ts
@@ -1,9 +1,15 @@
 import { MerkleTree, Maker } from "@looksrare/sdk-v2";
 import { BigNumberish, BytesLike } from "ethers";
 
+export interface Referrer {
+  address: string;
+  rate: BigNumberish;
+}
+
 export interface MakerOrderFromAPI extends Maker {
   signature: string;
   merkleTree: MerkleTree;
+  referrer?: Referrer;
 }
 
 /** LooksRare order extra data object inside TradeData */

--- a/src/utils/LooksRareV2/transformLooksRareV2Listings.ts
+++ b/src/utils/LooksRareV2/transformLooksRareV2Listings.ts
@@ -7,6 +7,7 @@ import { ChainId, QuoteType } from "@looksrare/sdk-v2";
 export default async function transformLooksRareV2Listings(
   chainId: ChainId,
   signer: ethers.Signer,
+  referrer: string,
   listings: Array<MakerOrderFromAPI>,
   proxy: string
 ): Promise<TradeData> {
@@ -59,6 +60,6 @@ export default async function transformLooksRareV2Listings(
     selector: PROXY_EXECUTE_SELECTOR,
     orders,
     ordersExtraData: ordersExtraDataBytes,
-    extraData: constants.HashZero,
+    extraData: referrer,
   };
 }


### PR DESCRIPTION
* chore: Referrer type add to MakerOrderFromAPI

* chore: Split looksRareV2 orders by referrer address inside transformListings

* refactor: Move order separation logic inside transformLooksRareV2Listing private function

* chore: add in referrer to transformLooksRareV2Listings

* test: Test fixes after referrer split

* test: Refactor tests to be fit for order split testing

* test: groups orders with different referrers into different TradeData

* test: group orders into TradData tests

* test: execute multiple orders

* fix: Push to tradeData instead of replace

* fix: Change looksRareTradeData name to looksRareV2Listings

* fix: Update spacing in comment in src/LooksRareAggregator.ts



* fix: makerOrderFromAPIs to makerOrdersFromAPI naming fix in Update src/__tests__/aggregatorExecuteLooksRareV2.test.ts



* fix: Variable makerOrdersFromAPI fix error

* fix: Set 0 as default value for none in tests

* fix: Remove referrerFromAPI declaration in tests

---------